### PR TITLE
Gms 9 change language

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -12,10 +12,12 @@
 const {
     language_details: languageDetails,
     default_language: defaultLanguage,
+    languages,
 } = require('./src/data/languages.json')
 
 const {
     menu_structure: menuStructure,
+    pages,
 } = require('./src/data/menuStructure.json')
 
 const makeLocalisedPath = (languageCode, pagePath, isIndexPage) => {
@@ -26,6 +28,87 @@ const makeLocalisedPath = (languageCode, pagePath, isIndexPage) => {
     }
 
     return isDefaultLanguage ? `/${pagePath}` : `/${languageCode}/${pagePath}`
+}
+
+/**
+ * Create a dictionary of page_keys and slugs for the menu structure for each language
+ */
+const makeLanguageMenuDictionary = (nodes) => {
+    const makeMenuSkeleton = () => {
+        return menuStructure.map((item) => {
+            const subMenu = (item.submenu_page_keys.length === 0)
+                ? []
+                : item.submenu_page_keys.map((key) => ({
+                    pageKey: key,
+                    homePage: false,
+                    slug: ''
+                }))
+            return ({
+                pageKey: item.page_key,
+                homePage: item.home_page,
+                slug: '',
+                subMenu,
+            })
+        })
+    }
+
+    const dictionarySkeleton = {}
+    pages.forEach((pageKey) => {
+        dictionarySkeleton[pageKey] = ''
+    })
+
+    const menus = {}
+    const pageDictionary = {}
+    languages.forEach((languageCode) => {
+        menus[languageCode] = makeMenuSkeleton()
+        pageDictionary[languageCode] = { ...dictionarySkeleton }
+    })
+
+    const addSlugToDictionary = (language, pageKey, slug) => {
+        if (!languages.includes(language)) return
+        if (typeof slug !== 'string') return
+        if (typeof pageKey !== 'string') return
+        pageDictionary[language][pageKey] = slug
+    }
+
+    nodes.forEach(({ node: { frontmatter: { slug, page_key: pageKey, language } } }) => {
+        addSlugToDictionary(language, pageKey, slug, pageDictionary)
+    })
+
+    const getPageSlug = (language, pageKey) => {
+        if (!Object.keys(pageDictionary).includes(language)) return ''
+        if (!Object.keys(pageDictionary[language]).includes(pageKey)) return ''
+
+        return pageDictionary[language][pageKey]
+    }
+
+    const addSlugToMenu = (language, slug, firstLevelIndex, secondLevelIndex = -1) => {
+        const firstLevel = menus[language][firstLevelIndex]
+        if (secondLevelIndex > -1) {
+            if (firstLevel.subMenu && firstLevel.subMenu.length > 0) {
+                firstLevel.subMenu[secondLevelIndex].slug = slug
+            }
+            return
+        }
+        firstLevel.slug = slug
+    }
+
+    Object.keys(menus).forEach((languageCode) => {
+        const menu = menus[languageCode]
+        menu.forEach((item, i) => {
+            const pageSlug = getPageSlug(languageCode, item.pageKey)
+            addSlugToMenu(languageCode, pageSlug, i)
+
+            if (item.subMenu && item.subMenu.length > 0) {
+                item.subMenu.forEach((subItem, j) => {
+                    const subPageSlug = getPageSlug(languageCode, subItem.pageKey)
+                    addSlugToMenu(languageCode, subPageSlug, i, j)
+                })
+            }
+        })
+    })
+
+    return [menus, pageDictionary]
 }
 
 exports.createPages = async ({ actions, graphql, reporter }) => {
@@ -52,6 +135,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
         reporter.panicOnBuild(`Error while running GraphQL query.`)
         return
     }
+    const [languageMenuStructures, pageKeyDictionary] = makeLanguageMenuDictionary(result.data.allMarkdownRemark.edges)
     result.data.allMarkdownRemark.edges.forEach(({ node }) => {
         const currentLanguage = languageDetails.find(
             ({ language_code: languageCode }) => node.frontmatter.language === languageCode,
@@ -64,6 +148,8 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
 
         if (!currentLanguage) return
 
+        const languageMenuStructure = languageMenuStructures[currentLanguage.language_code]
+
         createPage({
             path: makeLocalisedPath(currentLanguage.language_code, node.frontmatter.slug, isIndexPage),
             component: pageTemplate,
@@ -71,6 +157,8 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
                 // additional data can be passed via context
                 languageCode: currentLanguage.language_code,
                 pageKey: node.frontmatter.page_key,
+                menuStructure: languageMenuStructure,
+                pageKeyDictionary,
             },
         })
     })

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -69,8 +69,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
             component: pageTemplate,
             context: {
                 // additional data can be passed via context
-                originalPath: node.frontmatter.slug,
-                lang: currentLanguage.language_code,
+                languageCode: currentLanguage.language_code,
                 pageKey: node.frontmatter.page_key,
             },
         })

--- a/src/components/languagePicker/languagePicker.js
+++ b/src/components/languagePicker/languagePicker.js
@@ -3,19 +3,46 @@ import { navigate } from 'gatsby'
 import { useTranslation } from 'react-i18next'
 import { Menu, MenuItem, IconButton } from '@material-ui/core/'
 
-import { language_details as languageDetails, default_language as defaultLanguage } from '../../data/languages.json'
+import {
+    language_details as languageDetails,
+    default_language as defaultLanguage
+} from '../../data/languages.json'
+import { menu_structure as menuStructure } from '../../data/menuStructure.json'
 import { usePageContext } from '../pageContext'
 
 import Globe from '../../assets/svg/navIcons/globe.svg'
 
 function LanguagePicker() {
-    const { originalPath } = usePageContext()
+    const {
+        pageKey,
+        pageKeyDictionary,
+    } = usePageContext()
     const { i18n } = useTranslation()
 
     const [anchorEl, setAnchorEl] = React.useState(null)
 
-    const makePath = (languageCode) => {
+    const makeLanguagePath = (languageCode) => {
         return languageCode === defaultLanguage ? '/' : `/${languageCode}`
+    }
+
+    const isHomePage = () => {
+        const menuItem = menuStructure.find((firstLevelItem) => {
+            if (firstLevelItem.page_key === pageKey) {
+                return true
+            }
+            return false
+        })
+        return menuItem ? menuItem.home_page : false
+    }
+
+    const makeLocalisedPath = (languageCode) => {
+        const languagePath = makeLanguagePath(languageCode)
+        if (isHomePage()) return languagePath
+
+        const newSlug = pageKeyDictionary[languageCode][pageKey]
+
+        const isDefaultLanguage = languageCode === defaultLanguage
+        return isDefaultLanguage ? `/${newSlug}` : `/${languageCode}/${newSlug}`
     }
 
     const handleOpenMenu = event => {
@@ -29,8 +56,8 @@ function LanguagePicker() {
     const handleLangChange = ({ language_code: languageCode }) => {
         handleCloseMenu()
         i18n.changeLanguage(languageCode)
-        const path = makePath(languageCode)
-        navigate(`${path}${originalPath}`)
+        const path = makeLocalisedPath(languageCode)
+        navigate(path)
     }
 
     return (
@@ -62,7 +89,7 @@ function LanguagePicker() {
                         key={lang.language_code}
                         classes={{ root: 'langSelectorItem' }}
                         data-test={`languagePicker-option-${lang.language_code}`}
-                        data-value={makePath(lang.language_code)}
+                        data-value={makeLanguagePath(lang.language_code)}
                         onClick={() => handleLangChange(lang)}
                     >
                         {lang.language_name.toUpperCase()}

--- a/src/components/languagePicker/languagePicker.js
+++ b/src/components/languagePicker/languagePicker.js
@@ -5,7 +5,8 @@ import { Menu, MenuItem, IconButton } from '@material-ui/core/'
 
 import {
     language_details as languageDetails,
-    default_language as defaultLanguage
+    default_language as defaultLanguage,
+    languages,
 } from '../../data/languages.json'
 import { menu_structure as menuStructure } from '../../data/menuStructure.json'
 import { usePageContext } from '../pageContext'
@@ -84,17 +85,19 @@ function LanguagePicker() {
                 anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
                 transformOrigin={{ vertical: 'top', horizontal: 'center' }}
             >
-                {languageDetails.map(lang => (
-                    <MenuItem
-                        key={lang.language_code}
-                        classes={{ root: 'langSelectorItem' }}
-                        data-test={`languagePicker-option-${lang.language_code}`}
-                        data-value={makeLanguagePath(lang.language_code)}
-                        onClick={() => handleLangChange(lang)}
-                    >
-                        {lang.language_name.toUpperCase()}
-                    </MenuItem>
-                ))}
+                {languageDetails
+                    .filter((lang) => languages.includes(lang.language_code))
+                    .map(lang => (
+                        <MenuItem
+                            key={lang.language_code}
+                            classes={{ root: 'langSelectorItem' }}
+                            data-test={`languagePicker-option-${lang.language_code}`}
+                            data-value={makeLanguagePath(lang.language_code)}
+                            onClick={() => handleLangChange(lang)}
+                        >
+                            {lang.language_name.toUpperCase()}
+                        </MenuItem>
+                    ))}
             </Menu>
         </>
     )

--- a/src/templates/PageTemplate.js
+++ b/src/templates/PageTemplate.js
@@ -25,8 +25,8 @@ function PageTemplate({ data }) {
 }
 
 export const pageQuery = graphql`
-    query($originalPath: String!, $lang: String!) {
-        markdownRemark(frontmatter: { slug: { eq: $originalPath }, language: { eq: $lang } }) {
+    query($pageKey: String!, $languageCode: String!) {
+        markdownRemark(frontmatter: { page_key: { eq: $pageKey }, language: { eq: $languageCode } }) {
             html
             frontmatter {
                 title
@@ -42,7 +42,6 @@ PageTemplate.propTypes = {
         markdownRemark: PropTypes.shape({
             frontmatter: PropTypes.shape({
                 title: PropTypes.string,
-                date: PropTypes.string,
             }),
             html: PropTypes.string,
         }),


### PR DESCRIPTION
Ability to change language for any page.

The current setup allows for page slugs to be translateable. The change language dropdown, searches for the correct slug for the current pageKey and navigates the user there. If the page doesn't actually exist yet, it will 404